### PR TITLE
Support for ReplyTo and config parsing

### DIFF
--- a/FormWithAttachments/meta.yaml
+++ b/FormWithAttachments/meta.yaml
@@ -1,5 +1,5 @@
 name: 'Form with Attachments'
-version: '1.1'
+version: '1.2'
 description: 'Sends form submissions as email with attachment'
 developer: 'wild'
 developer_url: 'https://wild.as'

--- a/FormWithAttachments/settings.yaml
+++ b/FormWithAttachments/settings.yaml
@@ -11,7 +11,6 @@ fields:
             type: suggest
             mode: form_with_attachments.formsets
             display: Formset
-            instructions: Select formset
             max_items: 1
           settings:
             type: grid
@@ -20,13 +19,16 @@ fields:
               recipient:
                 type: text
                 instructions: 'Enter recipient e-mail'
+              reply_to:
+                type: text
+                display: 'Reply To'
+                instructions: 'Enter if you want reply to a different email address'
               template:
                 type: suggest
                 mode: form_with_attachments.email_templates
                 max_items: 1
               subject:
                 type: text
-                instructions: 'Enter e-mail subjecet'
           file_deletion:
             type: toggle
             display: File deletion


### PR DESCRIPTION
With config parsing you can use {{ email }} inside the “recipient” and “reply_to” field. This allows, for example, to set a dynamic recipient based on the email entered by the end user.